### PR TITLE
Timetable importer messages showing raw html

### DIFF
--- a/app/theme/templates/base-no-sponsors.html
+++ b/app/theme/templates/base-no-sponsors.html
@@ -131,7 +131,7 @@
                 <div class="messages">
                 {% for message in messages %}
                 <div class="alert-box {{ message.tags }}" data-alert>
-                   {{ message }}
+                   {% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
                    <a href="#" class="close">&times;</a>
                 </div>
                 {% endfor %}

--- a/app/theme/templates/base.html
+++ b/app/theme/templates/base.html
@@ -137,7 +137,7 @@
                 <div class="messages">
                 {% for message in messages %}
                 <div class="alert-box {{ message.tags }}" data-alert>
-                    {{ message }}
+                    {% if 'safe' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
                     <a href="#" class="close">&times;</a>
                 </div>
                 {% endfor %}

--- a/app/timetable/views.py
+++ b/app/timetable/views.py
@@ -27,7 +27,7 @@ def show(request):
         # source exists, parse it now.
         result = timetable_importer.export(s, code, this_url)
         if result == None:
-          messages.success(request, 'Success! Check <a href="http://calendar.google.com">Google Calendar</a>')
+          messages.success(request, 'Success! Check out your updated <a style="font-weight:bold;" href="http://calendar.google.com">Google Calendar</a>', extra_tags='safe')
           return render_to_response('timetable-importer/timetable-importer.html', context_instance=RequestContext(request))
       elif f == 'use-login' and zu and zp:
         # scrape myUNSW for available semesters
@@ -43,7 +43,7 @@ def show(request):
         # create calendar by scraping myUNSW
         result = timetable_importer.exportByScraping(zu, zp, semester, code, this_url)
         if result == None:
-          messages.success(request, 'Success! Check <a href="http://calendar.google.com">Google Calendar</a>')
+          messages.success(request, 'Success! Check out your updated <a style="font-weight:bold;" href="http://calendar.google.com">Google Calendar</a>', extra_tags='safe')
           return render_to_response('timetable-importer/timetable-importer.html', context_instance=RequestContext(request))
       messages.error(request, result)
       return render_to_response('timetable-importer/timetable-importer.html',


### PR DESCRIPTION
**Before:**
![screenshot](http://i.imgur.com/gf0dPim.jpg)

**After:**
![screenshot](http://i.imgur.com/skHrOPH.jpg)

I used the following solution http://stackoverflow.com/q/2053258 for html to be printed out through the django messages framework.

Also, to get that hyperlink (even) bolder, `<b>` or `<strong>` didn't work (the message seems to be already bold), so I used an inline bold instead.